### PR TITLE
update required for django 2.2

### DIFF
--- a/jfu/templatetags/jfutags.py
+++ b/jfu/templatetags/jfutags.py
@@ -1,5 +1,5 @@
-from django.template.context_processors import csrf
-from django.core.urlresolvers import reverse
+from django.middleware import csrf
+from django.urls import reverse
 from django.template import Library, loader
 
 register = Library()


### PR DESCRIPTION
csrf ref update for django 2.2

https://docs.djangoproject.com/en/2.2/_modules/django/template/context_processors/

